### PR TITLE
Gracefully handle null response body

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -134,7 +134,9 @@ func Check(resp *http.Response, err error) (*http.Response, error) {
 		err = CheckStatus(resp)
 	}
 	if err != nil {
-		_ = resp.Body.Close()
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
 		return nil, err
 	}
 	return resp, nil

--- a/errors.go
+++ b/errors.go
@@ -77,13 +77,13 @@ func extractMessage(resp *http.Response) string {
 			return fmt.Sprintf("<invalid json in response body: %v>", err)
 		}
 
-		keys := make([]string, len(doc), 0)
+		keys := make([]string, 0, len(doc))
 		for k := range doc {
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)
 
-		fields := make([]string, len(doc), 0)
+		fields := make([]string, 0, len(doc))
 		for _, k := range keys {
 			fields = append(fields, fmt.Sprintf("%s: %v", k, doc[k]))
 		}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,29 @@
+package hterrors
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestJSONResponse(t *testing.T) {
+	err := CheckStatus(&http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+		Body: io.NopCloser(strings.NewReader(`{"foo": "bar", "baz": "quux"}`)),
+		Request: &http.Request{
+			Method: "GET",
+			URL:    &url.URL{},
+		},
+	})
+	if err == nil {
+		t.Fatalf("Expected error; got nil")
+	}
+	if !strings.Contains(err.Error(), "foo: bar") {
+		t.Errorf("Expected error message to contain fields from JSON response; instead got %q", err.Error())
+	}
+}


### PR DESCRIPTION
While the standard net/http package guaruntees that responses will
always be non-nil, other http libraries like hashicorp/go-retryablehttp
can sometimes return valid responses with a nil Body. This change
makes hterrors.Check explicitly check for nil response body to
avoid nil dereference panic.